### PR TITLE
Improve choosing

### DIFF
--- a/styles/main.less
+++ b/styles/main.less
@@ -8,6 +8,9 @@
   margin-left: -50px;
   font-size: 10em;
   display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
   z-index: 11;
   width: 100%;
   &.active {

--- a/styles/main.less
+++ b/styles/main.less
@@ -22,6 +22,7 @@
     color: fade(@syntax-text-color,50);
   }
   &.last-focused {
+    text-decoration: underline;
   }
 }
 

--- a/styles/main.less
+++ b/styles/main.less
@@ -1,11 +1,7 @@
 @import "syntax-variables";
 .choose-pane {
   position: absolute;
-  top: 50%;
-  left: 50%;
   color: @syntax-text-color;
-  margin-top: -100px;
-  margin-left: -50px;
   font-size: 10em;
   display: flex;
   flex-direction: column;

--- a/styles/main.less
+++ b/styles/main.less
@@ -1,6 +1,11 @@
 @import "syntax-variables";
 .choose-pane {
+  background-color: rgba(112,182,101,.1);
   position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
   color: @syntax-text-color;
   font-size: 10em;
   display: flex;
@@ -9,11 +14,20 @@
   align-items: center;
   z-index: 11;
   width: 100%;
+  &::after {
+    font-size: 14px;
+  }
   &.active {
-    color: @syntax-color-added;
+    background-color: rgba(0,0,0,0.5);
+    color: fade(@syntax-text-color,50);
+    &::after {
+      content: 'Current Pane';
+    }
   }
   &.last-focused {
-    text-decoration: underline;
+    &::after {
+      content: 'Last Focused';
+    }
   }
 }
 

--- a/styles/main.less
+++ b/styles/main.less
@@ -20,14 +20,8 @@
   &.active {
     background-color: rgba(0,0,0,0.5);
     color: fade(@syntax-text-color,50);
-    &::after {
-      content: 'Current Pane';
-    }
   }
   &.last-focused {
-    &::after {
-      content: 'Last Focused';
-    }
   }
 }
 


### PR DESCRIPTION
The current behaviour makes choosing panes a little confusing. It's difficult to tell which pane is the current pane vs target panes. With this PR I hope to make choosing panes a little more obvious.

Changes:
- Centered pane children using flexbox
- Dim current pane
- Highlight target panes (in green)
- State last focused and current pane in each respective panes

Screencap:
![panes](https://cloud.githubusercontent.com/assets/278293/23330516/9b4dccb8-fb8a-11e6-9e30-1a37b2ca444f.gif)

Let me know your thoughts.